### PR TITLE
Added tools.jar explicitly to dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,13 @@
             <artifactId>HdrHistogram</artifactId>
             <version>1.0.8</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+            <version>1.6.0</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
     </dependencies>
     
 </project>


### PR DESCRIPTION
On Mac OS X 10.9 with java 1.7.0_45 I couldn't get it compiled without adding the tools.jar as an explicit dependency. 
