### PR TITLE
[minor] fixed typo in launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ that may cause the running application to not be continuously runnable.
 
 jHiccup can be executed in one of three main ways:
 
-1. It can be run as a Java agent (using: java -javaagent=jHiccup.jar)
+1. It can be run as a Java agent (using: java -javaagent:jHiccup.jar)
 
 2. It can be injected into a running application (using: jHiccup -p <pid>)
 


### PR DESCRIPTION
PS. I just changed one line, the last line change was done by Github automatically. It probably added a new line character.
