### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jHiccup can be executed in one of three main ways:
 
 ----------------------------------------------------------------------------
 
-###Example jHiccup plot 
+### Example jHiccup plot 
 ![example plot]
  
 ----------------------------------------------------------------------------


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
