### PR TITLE
Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,11 +234,6 @@
             <artifactId>HdrHistogram</artifactId>
             <version>2.1.11</version>
         </dependency>
-        <dependency>
-            <groupId>org.heaputils</groupId>
-            <artifactId>HeapUseWatcher</artifactId>
-            <version>1.0.1</version>
-        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Hello, I noticed that dependency `org.heaputils:HeapUseWatcher` in commit https://github.com/giltene/jHiccup/commit/3a6da976a9457dc61e34613f4f18c091a4b07360. However, I don't think this dependency is used in jHiccup.